### PR TITLE
fix: agent setting block is now fully optional

### DIFF
--- a/modules/tasks/main.tf
+++ b/modules/tasks/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_container_registry_task" "tasks" {
   tags                  = try(each.value.tags, var.tags, null)
 
   dynamic "agent_setting" {
-    for_each = each.value.agent_setting != null ? [each.value.agent_setting] : []
+    for_each = try(each.value.agent_setting, null) != null ? [each.value.agent_setting] : []
     content {
       cpu = try(agent_setting.value.cpu, 2)
     }


### PR DESCRIPTION
## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Agent_setting block is optional as mentioned in the documentation, see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_task 
It is not required when the agent_pool_name is set, see also https://github.com/hashicorp/terraform-provider-azurerm/issues/28085

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
